### PR TITLE
[codex] プロフィールREADMEを動的スコアボード化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,40 @@
-### Hi there 👋
+<div align="center">
 
-<p align="left"> 
-  <img alt="Top Langs" height="150px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=mado-m&layout=compact&show_icons=true&theme=onedark" />
-  <img alt="github stats" height="150px" src="https://github-readme-stats.vercel.app/api?username=mado-m&theme=onedark&show_icons=ture" />
-</p>
+<img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=170&color=0:0D1117,55:164E63,100:F6D365&text=mado-m&fontColor=F8FAFC&fontSize=58&fontAlignY=38&desc=live%20GitHub%20signal%20board&descAlignY=62&descSize=16&animation=fadeIn" />
 
-[![trophy](https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&column=7)](https://github.com/ryo-ma/github-profile-trophy)
+<br />
 
-<!--
-**mado-m/mado-m** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+<img alt="GitHub followers" src="https://img.shields.io/github/followers/mado-m?label=followers&style=for-the-badge&logo=github&logoColor=white&labelColor=0D1117&color=F6D365" />
 
-Here are some ideas to get you started:
+<br />
+<br />
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+<a href="https://github.com/ryo-ma/github-profile-trophy">
+  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+</a>
+
+<br />
+<br />
+
+<img height="182" alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
+<img height="182" alt="GitHub stats summary" src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=mado-m&theme=github_dark" />
+
+<br />
+
+<img height="190" alt="Productive time" src="https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=mado-m&theme=github_dark&utcOffset=9" />
+<img height="190" alt="Repos per language" src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=mado-m&theme=github_dark" />
+<img height="190" alt="Most commit language" src="https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=mado-m&theme=github_dark" />
+
+<br />
+
+<img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark" />
+
+<br />
+
+<img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
+
+<br />
+
+<img width="100%" alt="" src="https://capsule-render.vercel.app/api?type=waving&height=90&section=footer&color=0:0D1117,55:164E63,100:F6D365" />
+
+</div>


### PR DESCRIPTION
## 変更内容
- SRE / 技術スタック / Featured Work / 公開リポジトリ紹介を README から削除
- capsule-render のヘッダー / フッターで `mado-m` のブランド感を追加
- github-profile-trophy を主役に戻し、Commits / Experience / Issues / Stars / Followers / PullRequest / Repositories に絞って表示
- followers、streak、summary cards、activity graph をダークテーマで統一
- 訪問者計測系の profile views badge はセキュリティ / プライバシー優先で不採用
- `assets/hero.svg` と `github-readme-stats` 依存を使わない構成に変更

## 背景
GitHub プロフィール本体に肩書きやリンクが表示されているため、README では情報を重複させず、訪問時に目に入る動的な活動シグナルへ絞りました。公開できる代表 work が private リポジトリ中心であることも踏まえ、公開 repo の紹介セクションは削除しています。

## セキュリティ
- README に token / secret / private repository 名や private stats は含めていません
- private repository の詳細を外部サービスへ渡す構成にはしていません
- 訪問者トラッキング用途の badge は削除しています

## 確認
- `git diff --cached --check`
- `rg` で SRE / Featured Work / `assets` / `github-readme-stats` / token / secret / private 参照が残っていないことを確認
- README に埋め込んだ主要な動的画像 URL が `200 image/svg+xml` を返すことを確認