### PR TITLE
[codex] invalid表示のFollowersバッジを削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 <img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=170&color=0:0D1117,55:164E63,100:F6D365&text=mado-m&fontColor=F8FAFC&fontSize=58&fontAlignY=38&desc=live%20GitHub%20signal%20board&descAlignY=62&descSize=16&animation=fadeIn" />
 
 <br />
-
-<img alt="GitHub followers" src="https://img.shields.io/github/followers/mado-m?label=followers&style=for-the-badge&logo=github&logoColor=white&labelColor=0D1117&color=F6D365" />
-
-<br />
 <br />
 
 <a href="https://github.com/ryo-ma/github-profile-trophy">


### PR DESCRIPTION
## 変更内容
- README の Shields.io followers badge を削除

## 背景
GitHub プロフィール上で followers badge が `INVALID` と表示されていました。URL を直接確認すると正常な SVG が返るタイミングもあるため、Shields.io / GitHub 画像キャッシュの一時的な不整合と考えられます。プロフィール左側に followers 数は標準表示されるため、冗長で壊れやすい badge は削除します。

## セキュリティ
- 新しい外部サービスは追加していません
- token / secret / private repository 情報は含めていません

## 確認
- `git diff --cached --check`
- README に `img.shields.io` / `komarev` / `profile views` 参照が残っていないことを確認