### PR TITLE
[codex] 空の言語別コミットカードを削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 
 <img height="190" alt="Productive time" src="https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=mado-m&theme=github_dark&utcOffset=9" />
 <img height="190" alt="Repos per language" src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=mado-m&theme=github_dark" />
-<img height="190" alt="Most commit language" src="https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=mado-m&theme=github_dark" />
 
 <br />
 


### PR DESCRIPTION
## 変更内容
- README から `most-commit-language` カードを削除

## 背景
`Top Languages by Commit` が `There are no any commits in the last year` と空表示になっていました。public repository の commit language 集計が取れていない状態のため、空カードを残さず `Productive time` と `Top Languages by Repo` の2枚構成に整理します。

## セキュリティ
- 新しい外部サービスは追加していません
- token / secret / private repository 情報は含めていません

## 確認
- `git diff --cached --check`
- README に `most-commit-language` / `Top Languages by Commit` / `github-readme-stats` 参照が残っていないことを確認