### PR TITLE
[codex] 弱いプロフィールカードを削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@
 <br />
 
 <img height="182" alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
-<img height="182" alt="GitHub stats summary" src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=mado-m&theme=github_dark" />
-
-<br />
-
-<img height="190" alt="Productive time" src="https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=mado-m&theme=github_dark&utcOffset=9" />
-<img height="190" alt="Repos per language" src="https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=mado-m&theme=github_dark" />
 
 <br />
 


### PR DESCRIPTION
## 変更内容
- `GitHub stats summary` カードを削除
- `Productive time` カードを削除
- `Repos per language` カードを削除
- GitHub achievement trophies は元の7カード構成を維持

## 背景
`GitHub stats summary` は stars など弱い数値が目立ち、プロフィール全体の見栄えを下げていました。`Productive time` は下部の活動グラフと情報が重複し、`Repos per language` は public repository 情報だけに偏って Go のみ表示されるため、強いシグナルだけに絞ります。

## セキュリティ
- 新しい外部サービスは追加していません
- token / secret / private repository 情報は含めていません

## 確認
- `git diff --cached --check`
- README に `api/cards/stats` / `productive-time` / `repos-per-language` / `github-readme-stats` 参照が残っていないことを確認
- trophy URL が `200 image/svg+xml` を返すことを確認