### PR TITLE
[codex] プロフィールバナーを華やかにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=170&color=0:0D1117,55:164E63,100:F6D365&text=mado-m&fontColor=F8FAFC&fontSize=58&fontAlignY=38&desc=live%20GitHub%20signal%20board&descAlignY=62&descSize=16&animation=fadeIn" />
+<img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling" />
 
 <br />
 <br />
@@ -24,6 +24,6 @@
 
 <br />
 
-<img width="100%" alt="" src="https://capsule-render.vercel.app/api?type=waving&height=90&section=footer&color=0:0D1117,55:164E63,100:F6D365" />
+<img width="100%" alt="" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 
 </div>


### PR DESCRIPTION
## 変更内容
- capsule-render のヘッダー配色を teal / rose / gold の多色グラデーションに変更
- ヘッダーの高さ、文字サイズ、説明文、アニメーションを調整
- フッターも同じ配色に合わせ、`reversal=true` で流れを反転

## 背景
プロフィール README の上端と下端を、現在のスコアボード構成に合うファンシー寄りのブランド表現へ寄せるためです。画像ファイルは追加せず、既存の capsule-render URL パラメータだけで調整しています。

## セキュリティ
- 新しい外部サービスは追加していません
- token / secret / private repository 情報は含めていません
- SVG 内で XML エラーにならないよう、説明文に `&` は使っていません

## 確認
- `git diff --cached --check`
- 新しい header / footer URL が `200 image/svg+xml` を返すことを確認
- 一時保存した header / footer SVG を XML parse できることを確認