### PR TITLE
[claude] セクション間の余白を詰める

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 <img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling" />
 
 <br />
-<br />
 
 <a href="https://github.com/ryo-ma/github-profile-trophy">
   <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
 </a>
 
-<br />
 <br />
 
 <img height="182" alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />


### PR DESCRIPTION
## Summary
- 連続していた `<br />` を1つに減らし、バナー〜トロフィー〜ストリーク間の余白を詰めた

## Test plan
- [ ] GitHub上のREADMEレンダリングで余白が適切になっているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)