### PR TITLE
[claude] READMEのHTMLをフォーマットする

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,48 @@
 <div align="center">
 
-<img width="100%"
-     alt="mado-m live GitHub signal board"
-     src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling" />
+  <img
+    width="100%"
+    alt="mado-m live GitHub signal board"
+    src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling"
+  />
 
-<br />
+  <br />
 
-<a href="https://github.com/ryo-ma/github-profile-trophy">
-<img alt="GitHub achievement trophies"
-     src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
-</a>
+  <a href="https://github.com/ryo-ma/github-profile-trophy">
+    <img
+      alt="GitHub achievement trophies"
+      src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories"
+    />
+  </a>
 
-<br />
+  <br />
 
-<img height="182"
-     alt="Contribution streak"
-     src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
+  <img
+    height="182"
+    alt="Contribution streak"
+    src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC"
+  />
 
-<br />
+  <br />
 
-<img alt="Profile details"
-     src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark" />
+  <img
+    alt="Profile details"
+    src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark"
+  />
 
-<br />
+  <br />
 
-<img alt="Contribution activity graph"
-     src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
+  <img
+    alt="Contribution activity graph"
+    src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true"
+  />
 
-<br />
+  <br />
 
-<img width="100%"
-     alt=""
-     src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
+  <img
+    width="100%"
+    alt=""
+    src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A"
+  />
 
 </div>

--- a/README.md
+++ b/README.md
@@ -1,27 +1,36 @@
 <div align="center">
 
-<img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling" />
+<img width="100%"
+     alt="mado-m live GitHub signal board"
+     src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling" />
 
 <br />
 
 <a href="https://github.com/ryo-ma/github-profile-trophy">
-  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+<img alt="GitHub achievement trophies"
+     src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
 </a>
 
 <br />
 
-<img height="182" alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
+<img height="182"
+     alt="Contribution streak"
+     src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
 
 <br />
 
-<img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark" />
+<img alt="Profile details"
+     src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark" />
 
 <br />
 
-<img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
+<img alt="Contribution activity graph"
+     src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
 
 <br />
 
-<img width="100%" alt="" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
+<img width="100%"
+     alt=""
+     src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 
 </div>

--- a/README.md
+++ b/README.md
@@ -1,48 +1,36 @@
 <div align="center">
-
   <img
     width="100%"
     alt="mado-m live GitHub signal board"
     src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling"
   />
-
   <br />
-
   <a href="https://github.com/ryo-ma/github-profile-trophy">
     <img
       alt="GitHub achievement trophies"
       src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories"
     />
   </a>
-
   <br />
-
   <img
     height="182"
     alt="Contribution streak"
     src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC"
   />
-
   <br />
-
   <img
     alt="Profile details"
     src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark"
   />
-
   <br />
-
   <img
     alt="Contribution activity graph"
     src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true"
   />
-
   <br />
-
   <img
     width="100%"
     alt=""
     src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A"
   />
-
 </div>


### PR DESCRIPTION
## Summary
- js-beautify でREADME内のHTMLを整形
- タグ名を独立行にして属性を字下げ (`--wrap-attributes=force-expand-multiline`) で各要素の開始位置を視認しやすく
- 不要な空行を全削除して縦の余白を詰める
- markdownレンダリングを崩さないよう `<div>` 内側は2スペース字下げに留める (`--indent-size=2 --indent-inner-html=false`)

## Test plan
- [ ] GitHub上のREADMEレンダリングが従来と変わらず崩れていないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)