### PR TITLE
[claude] imgタグの属性を統一する

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
     <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   </a>
   <br />
-  <img height="182" alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
+  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
   <br />
   <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark" />
   <br />
   <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
   <br />
-  <img width="100%" alt="" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
+  <img width="100%" alt="mado-m profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 </div>


### PR DESCRIPTION
## Summary
- ストリーク画像から不要な `height="182"` を削除(高さ合わせ用だった隣接カードは過去PRで削除済み)
- フッター波の空 `alt=""` に意味のある説明を追加

## ルール
3つに統一しました:
- 波バナー(上下): `width="100%"` (全幅装飾)
- カード系: サイズ属性なし(各サービスのデフォルトサイズ)
- 全画像にmeaningfulな `alt`

## Test plan
- [ ] GitHub上のREADMEレンダリングで全画像が崩れず表示されているか確認
- [ ] ストリーク画像のサイズが許容範囲か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)