### PR TITLE
[claude] トロフィー画像のリンクを外す

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <div align="center">
   <img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling" />
   <br />
-  <a href="https://github.com/ryo-ma/github-profile-trophy">
-    <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
-  </a>
+  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />
   <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
   <br />


### PR DESCRIPTION
## Summary
- トロフィー画像を囲っていた `<a href="https://github.com/ryo-ma/github-profile-trophy">` を削除
- streak-stats / profile-summary-cards / activity-graph も同じくOSS製だがリンクは付いていないので、トロフィーだけ付いていたのを統一

## Test plan
- [ ] GitHub上でトロフィー画像が変わらず表示されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)