### PR TITLE
[claude] バナーのdescを抽象的な文言に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=signals%20-%20streaks%20-%20trophies&descAlignY=60&descSize=17&animation=twinkling" />
+  <img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17&animation=twinkling" />
   <br />
   <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />


### PR DESCRIPTION
## Summary
- バナーのサブタイトル `signals - streaks - trophies` をカード構成に依存しない `live GitHub signal board` に変更
- alt text `mado-m live GitHub signal board` とも揃う
- 今後カードの追加・削除があっても文言を変更しなくて済む

## Test plan
- [ ] GitHub上のREADMEバナーで新しいdescが正しく表示されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)