### PR TITLE
[claude] バナーから不要な width="100%" を外す

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img width="100%" alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17&animation=twinkling" />
+  <img alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17&animation=twinkling" />
   <br />
   <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />
@@ -9,5 +9,5 @@
   <br />
   <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
   <br />
-  <img width="100%" alt="mado-m profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
+  <img alt="mado-m profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 </div>


### PR DESCRIPTION
## Summary
- 上下の波バナーから `width="100%"` を削除
- 検証の結果、属性なしでも全幅で表示されることを確認 ([検証用コミット](https://github.com/mado-m/mado-m/blob/34c03482a4d352026dee1f08e673531243f73660/README.md))
- これで全imgタグから width/height 属性が消え、より統一感のある状態に

## Test plan
- [ ] GitHub上のREADMEレンダリングで波バナーが従来通り全幅表示されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)