### PR TITLE
[claude] ヘッダーバナーの点滅アニメーションを外す

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17&animation=twinkling" />
+  <img alt="mado-m live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
   <br />
   <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />


### PR DESCRIPTION
## Summary
- ヘッダー波バナーの `animation=twinkling` を削除
- text/desc の点滅が目障りだったため静止画化

## Test plan
- [ ] GitHub上のREADMEバナーで text/desc が点滅せず静止表示されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)