### PR TITLE
[claude] バナーaltの先頭をdescと揃えて小文字化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="Live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
+  <img alt="live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
   <br />
   <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />


### PR DESCRIPTION
## Summary
- alt text `Live GitHub signal board` を視覚テキスト `desc=live%20GitHub%20signal%20board` に合わせて小文字化
- 視覚テキストとalt textの先頭文字を統一

## Test plan
- [ ] altは画面に出ないので挙動には影響なし、ソース上のaltが `live GitHub signal board` に変わっているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)