### PR TITLE
[claude] [比較用] カード4種を dracula テーマに統一する

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
   <br />
   <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=dracula&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />
-  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=dracula" />
+  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=dracula&hide_border=true" />
   <br />
   <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=dracula" />
   <br />
-  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=dracula" />
+  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=dracula&hide_border=true" />
   <br />
   <img alt="Profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 </div>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
   <img alt="live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
   <br />
-  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=dracula&column=7" />
   <br />
-  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
+  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=dracula" />
   <br />
-  <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark" />
+  <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=dracula" />
   <br />
-  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
+  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=dracula" />
   <br />
   <img alt="Profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 </div>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img alt="live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
   <br />
-  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=dracula&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=dracula&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />
   <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=dracula" />
   <br />

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img alt="live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
   <br />
-  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=dracula&column=7" />
+  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=dracula&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />
   <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=dracula" />
   <br />


### PR DESCRIPTION
## Summary
[#17](https://github.com/mado-m/mado-m/pull/17) (tokyonight案) との比較用ドラフトPR。配色比較してマージする方を選んでください。

## tokyonight案との違い
- 命名が4サービス完全一致 (`dracula` のみ、ハイフン違いなし)
- 配色は dark紫 + ピンク + 緑のドラキュラ調
- バナーの teal/rose/amber グラデとは別世界観なので、本気で揃えるならバナーも変更推奨

## 変更内容
- trophy: `theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&title=...` → `theme=dracula&column=7`
- streak: 大量のカスタムカラー → `theme=dracula`
- summary-cards: `theme=github_dark` → `theme=dracula`
- activity-graph: `bg_color=...&color=...&line=...&point=...&area=true&hide_border=true` → `theme=dracula`

## 残ったカスタム
- バナー (上下): capsule-render はテーマ機能を持たないので、グラデ色指定は維持

## Test plan
- [ ] PR diffプレビューで dracula 配色のカードを確認
- [ ] [#17](https://github.com/mado-m/mado-m/pull/17) と比較してどちらの配色が好みか判断
- [ ] バナーとの調和も比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)