### PR TITLE
[claude] カード4種を radical テーマに統一する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
   <img alt="live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
   <br />
-  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=radical&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   <br />
-  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&hide_border=true&background=0D1117&ring=5EEAD4&fire=F6D365&currStreakLabel=5EEAD4&sideLabels=C9D1D9&dates=8B949E&sideNums=F8FAFC&currStreakNum=F8FAFC" />
+  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=radical&hide_border=true" />
   <br />
-  <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=github_dark" />
+  <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=radical" />
   <br />
-  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&bg_color=0D1117&color=C9D1D9&line=5EEAD4&point=F6D365&area=true&hide_border=true" />
+  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=redical&hide_border=true" />
   <br />
   <img alt="Profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 </div>


### PR DESCRIPTION
## Summary
- trophy / streak / summary-cards / activity-graph の各種カスタムカラー指定を廃止し、共通プリセット **radical** に統一
- activity-graph のみ命名仕様で `redical` (スペル違い) を使用
- dark navy 背景 + ホットピンク / シアン / イエローのネオンアクセントで GitHub に馴染みつつ華やか
- 副次効果として URL も短くなり可読性向上

## 変更内容
- trophy: `theme=onedark&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7&title=...` → `theme=radical&no-frame=true&no-bg=true&column=7&title=...`
- streak: 大量のカスタムカラー → `theme=radical&hide_border=true`
- summary-cards: `theme=github_dark` → `theme=radical`
- activity-graph: `bg_color=...&color=...&line=...&point=...&area=true&hide_border=true` → `theme=redical&hide_border=true`

## 残ったカスタム
- バナー (上下): capsule-render はテーマ機能を持たないのでグラデ色指定は維持
- trophy `no-frame=true&no-bg=true`: テーマ枠/背景の非表示(従来通り)
- trophy `column=7&title=...`: 7カラムレイアウトと表示カテゴリ指定
- streak/activity-graph `hide_border=true`: 外枠の非表示

## Test plan
- [ ] GitHub上で4カードがradical配色で統一感を持って表示されているか確認
- [ ] バナーとカードの色味の調和を確認
- [ ] trophyの7カラムレイアウトとカテゴリ(Reviewsなし)が崩れていないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)