### PR TITLE
[claude] activity graph の theme タイポを修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <br />
   <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=radical" />
   <br />
-  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=redical&hide_border=true" />
+  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=radical&hide_border=true" />
   <br />
   <img alt="Profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 </div>


### PR DESCRIPTION
## Summary
- [README.md:10](README.md) の activity graph URL で `theme=redical` となっていたタイポを `theme=radical` に修正。
- 他4カード ([README.md:4,6,8](README.md), 行8) はすでに `radical` に揃っており、このカードだけ外れていた。

## Test plan
- [ ] GitHub 上でレンダリングを確認し、activity graph が radical テーマで表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)