### PR TITLE
[claude] activity graph の redical テーマに HTML コメントで注釈を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <br />
   <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=radical" />
   <br />
+  <!-- "redical" は github-readme-activity-graph 独自の正規テーマ名 (typo ではない)。"radical" は同サービスに存在せず、指定すると default のピンク背景に fallback する。参考: https://github.com/Ashutosh00710/github-readme-activity-graph/pull/236 -->
   <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=redical&hide_border=true" />
   <br />
   <img alt="Profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />


### PR DESCRIPTION
## Summary
- [README.md:10](README.md) の activity graph 直前に HTML コメントを追加し、`theme=redical` が typo ではなく意図された指定であることを明記。
- 直前にこの値を「タイポ」と誤判定して `radical` に書き換える PR ([#20](https://github.com/mado-m/mado-m/pull/20), クローズ済) を出してしまったため、再発防止のドキュメンテーション。

## 調査結果

`github-readme-activity-graph` ([Ashutosh00710/github-readme-activity-graph](https://github.com/Ashutosh00710/github-readme-activity-graph)) の [src/styles/themes.ts](https://github.com/Ashutosh00710/github-readme-activity-graph/blob/main/src/styles/themes.ts) を確認。

- `redical` は同サービスに **正規テーマとして実在** (`bgColor: 141321` のダーク背景)。
- `radical` は同サービスには **存在しない** → 未定義テーマは `default` ケース (`bgColor: ffcfe9` のピンク背景) にフォールバックし、他カードと配色が崩れる。
- 配色から見て `redical` は `anuraghazra/github-readme-stats` の `radical` テーマ (色は完全一致) を移植したもので、上流側のタイポである可能性は高い。
- ただし上流ではリネーム提案 PR ([Ashutosh00710/github-readme-activity-graph#236](https://github.com/Ashutosh00710/github-readme-activity-graph/pull/236)) が「既存ユーザーが壊れる」を理由にメンテナによってクローズ済 (2025-08-21)。当面 `redical` のままが正しい。

## Test plan
- [ ] GitHub 上で README をプレビューし、HTML コメントが表示されないこと・activity graph がダーク背景でレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)