### PR TITLE
[codex] refactor: READMEの画像配置を構造化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 <div align="center">
+  <!-- Header -->
   <img alt="live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
-  <br />
-  <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=radical&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
-  <br />
-  <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=radical&hide_border=true" />
-  <br />
-  <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=radical" />
-  <br />
-  <!-- "redical" は github-readme-activity-graph 独自の正規テーマ名 (typo ではない)。"radical" は同サービスに存在せず、指定すると default のピンク背景に fallback する。参考: https://github.com/Ashutosh00710/github-readme-activity-graph/pull/236 -->
-  <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=redical&hide_border=true" />
-  <br />
+
+  <!-- Highlights -->
+  <p>
+    <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=radical&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+  </p>
+
+  <!-- Activity -->
+  <p>
+    <img alt="Contribution streak" src="https://streak-stats.demolab.com?user=mado-m&theme=radical&hide_border=true" />
+  </p>
+  <p>
+    <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=radical" />
+  </p>
+  <p>
+    <!-- "redical" は github-readme-activity-graph 独自の正規テーマ名 (typo ではない)。"radical" は同サービスに存在せず、指定すると default のピンク背景に fallback する。参考: https://github.com/Ashutosh00710/github-readme-activity-graph/pull/236 -->
+    <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=redical&hide_border=true" />
+  </p>
+
+  <!-- Footer -->
   <img alt="Profile footer wave" src="https://capsule-render.vercel.app/api?type=waving&height=110&section=footer&reversal=true&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A" />
 </div>


### PR DESCRIPTION
## 変更内容
- 最新の `main` を起点に README の画像群を Header / Highlights / Activity / Footer のコメントで区切りました
- `<br />` 連打をやめ、主要画像を `<p>` ブロックで整理しました
- 既存の `redical` 注釈は保持しました

## 背景
今後画像を増やす場合に、どの画像がどの役割か分かりやすくするためです。表示内容、画像 URL、alt、`theme=redical` は変更していません。

## 確認
- `git diff --check`