### PR TITLE
fix: use radical activity graph theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
     <img alt="Profile details" src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=mado-m&theme=radical" />
   </p>
   <p>
-    <!-- "redical" は github-readme-activity-graph 独自の正規テーマ名 (typo ではない)。"radical" は同サービスに存在せず、指定すると default のピンク背景に fallback する。参考: https://github.com/Ashutosh00710/github-readme-activity-graph/pull/236 -->
-    <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=redical&hide_border=true" />
+    <img alt="Contribution activity graph" src="https://github-readme-activity-graph.vercel.app/graph?username=mado-m&theme=radical&hide_border=true" />
   </p>
 
   <!-- Footer -->


### PR DESCRIPTION
## 概要
- github-readme-activity-graph の activity graph を `theme=radical` に変更しました。
- `radical` 未対応を前提にした古い注釈コメントを削除しました。

## 背景
- Ashutosh00710/github-readme-activity-graph#246 が merge され、`radical` が `redical` の alias として使えるようになったためです。

## 確認
- `git diff --check`
- README 内の activity graph URL が `theme=radical` になっていることを確認