### PR TITLE
docs: remove README header subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <!-- Header -->
-  <img alt="live GitHub signal board" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36&desc=live%20GitHub%20signal%20board&descAlignY=60&descSize=17" />
+  <img alt="" src="https://capsule-render.vercel.app/api?type=waving&height=190&color=0:0D1117,32:0F766E,68:FB7185,100:FDE68A&text=mado-m&fontColor=F8FAFC&fontSize=62&fontAlignY=36" />
 
   <!-- Highlights -->
   <p>


### PR DESCRIPTION
## 概要

- READMEのヘッダー画像からサブタイトル表示を削除
- 画像が読めない場合にも不要な説明文が表示されないよう、ヘッダー画像の `alt` を空に変更

## 確認

- README内に `live GitHub signal board` と `desc` 系パラメータが残っていないことを確認
- READMEのみの表示変更のため、自動テストは未実行
