### PR TITLE
fix: restore profile trophy image endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
   <!-- Highlights -->
   <p>
-    <img alt="GitHub achievement trophies" src="https://github-profile-trophy.vercel.app/?username=mado-m&theme=radical&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+    <img alt="GitHub achievement trophies" src="https://trophy.ryglcloud.net/?username=mado-m&theme=radical&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   </p>
 
   <!-- Activity -->


### PR DESCRIPTION
## 概要

- GitHub Profile Trophy の画像 URL を停止中の github-profile-trophy.vercel.app から公式 README 掲載の mirror endpoint に差し替えました。

## 背景

元の endpoint は HTTP 402 / x-vercel-error: DEPLOYMENT_DISABLED を返しており、GitHub プロフィール上で画像がリンク切れになっていました。

## 確認

- curl で差し替え先が HTTP 200 / image/svg+xml を返すことを確認しました。
