### PR TITLE
fix: restore profile trophy rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
   <!-- Highlights -->
   <p>
-    <img alt="GitHub achievement trophies" src="https://trophy.ryglcloud.net/?username=mado-m&theme=radical&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
+    <img alt="GitHub achievement trophies" src="https://trophygh.kolioaris.xyz/?username=mado-m&theme=radical&no-frame=true&no-bg=true&column=7&title=Commits,Experience,Issues,Stars,Followers,PullRequest,Repositories" />
   </p>
 
   <!-- Activity -->


### PR DESCRIPTION
## 概要
- プロフィール README の GitHub Profile Trophy 画像 URL を差し替えました。
- `trophy.ryglcloud.net` から、現在 SVG を正常に返す `trophygh.kolioaris.xyz` に変更しています。

## 背景
GitHub プロフィール上でトロフィー画像が camo の fetch error になっていました。旧エンドポイントは確認時にタイムアウトしており、GitHub Profile Trophy 公式 README に掲載されているロードバランス用エンドポイントのうち、`HTTP 200` かつ `image/svg+xml` を返すミラーに切り替えています。

## 検証
- `curl -I -L --max-time 20` で新 URL が `HTTP 200` / `image/svg+xml` を返すことを確認
- `git diff --check`
- `git diff --check origin/main..HEAD`
